### PR TITLE
Fix python_version format

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format

--- a/remedyforce.json
+++ b/remedyforce.json
@@ -14,10 +14,7 @@
     "logo_dark": "logo_bmcremedyforce_dark.svg",
     "product_version_regex": ".*",
     "min_phantom_version": "4.9.39220",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "license": "Copyright (c) 2016-2025 Splunk Inc.",
     "latest_tested_versions": [


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)